### PR TITLE
Allow undefined `Probe.element_geometry` during serialization

### DIFF
--- a/src/uff/probe.py
+++ b/src/uff/probe.py
@@ -40,17 +40,44 @@ class Probe(Serializable):
     # def deserialize(cls, data: dict):
     #     pass
 
-    # >> TODO: These parameters are not defined in the standard
-    number_elements: int
-    pitch: float
-    element_height: float
-    element_width: float
-    ##  <<
     transform: Transform
-    # TODO for conformity call `elements`
     element: List[Element]
     element_impulse_response: List[ImpulseResponse] = None
     focal_length: float = None
-    # >> TODO: These parameters are not defined in the standard
     element_geometry: List[ElementGeometry] = None
+    # # >> TODO: These parameters are not defined in the standard
+    number_elements: int = 0
+    pitch: float = 0
+    element_height: float = 0
+    element_width: float = 0
     ##  <<
+    ## TODO: add element list factory to generate element list from these parameters,
+    # and getters to generate properties from these properties.
+    # OPEN QUESTION: what to do when file contains extra properties that do not conform to standard?
+    # TODO idea for getters
+    # @property
+    # def number_elements(self):
+    #     return len(self.element)
+    # @property
+    # def pitch(self):
+    #     # check if all element spacings are the same
+    #     # return pitch
+    #     # else:
+    #     # catch and warn of non-standard spacing
+    #     return len(self.element)
+    #
+    # @property
+    # def element_width(self):
+    #     # check for conformal element width
+    #     # return element_width
+    #     # else:
+    #     # catch and warn of non-conformal element width
+    #     pass
+    #
+    # @property
+    # def element_height(self):
+    #     # check for conformal element height
+    #     # return element_height
+    #     # else:
+    #     # catch and warn of non-conformal element height
+    #     pass

--- a/src/uff/probe.py
+++ b/src/uff/probe.py
@@ -32,7 +32,7 @@ class Probe(Serializable):
         return 'probes'
 
     def serialize(self):
-        assert isinstance(self.element_geometry, list), \
+        assert self.element_geometry is None or isinstance(self.element_geometry, list), \
             'Probe.element_geometry should be a list of element geometries!'
         return super().serialize()
 

--- a/tests/test_probe.py
+++ b/tests/test_probe.py
@@ -18,8 +18,44 @@ def test_instantiation():
     e = Element(tt, eg, ir)
     p = Probe(transform=tt,
               element=e,
+              element_geometry=[eg],
               element_impulse_response=[ir],
               number_elements=128,
               pitch=0,
               element_height=0.15,
               element_width=0.3)
+
+
+def test_serialization():
+    t = Translation(1, 1, 1)
+    r = Rotation(0, 0, 0)
+    tt = Transform(t, r)
+    eg = ElementGeometry(Perimeter([Position(1, 1, 1)]))
+    ir = ImpulseResponse(0, 10, [1, 1, 1], '[m]')
+    e = Element(tt, eg, ir)
+    p = Probe(transform=tt,
+              element=e,
+              element_geometry=[eg],
+              element_impulse_response=[ir],
+              number_elements=128,
+              pitch=0,
+              element_height=0.15,
+              element_width=0.3)
+
+    p_ser = p.serialize()
+    pass
+
+
+def test_serialization_with_only_required_args():
+    t = Translation(1, 1, 1)
+    r = Rotation(0, 0, 0)
+    tt = Transform(t, r)
+    ir = ImpulseResponse(0, 10, [1, 1, 1], '[m]')
+    eg = ElementGeometry(Perimeter([Position(1, 1, 1)]))
+    e = Element(tt, eg, ir)
+    p = Probe(transform=tt,
+              element=e,
+              pitch=0)
+
+    p_ser = p.serialize()
+    pass


### PR DESCRIPTION
Closes #19 